### PR TITLE
Fix shebang to work on NixOS

### DIFF
--- a/gdb-ctest
+++ b/gdb-ctest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # MIT License
 #


### PR DESCRIPTION
I'm on a funny system with no `/bin/bash`. On Nix, bash is of course in `$PATH`, and there's `/usr/bin/env` for POSIX compatibility.

Fun fact: apparently POSIX says that one should not even assume `/bin/sh` exists, but [it's complicated](https://stackoverflow.com/questions/53116226/what-is-the-recommended-posix-sh-shebang).